### PR TITLE
Unbind process from network on disconnect on Android Q

### DIFF
--- a/src/android/WiFiManagerPlugin.java
+++ b/src/android/WiFiManagerPlugin.java
@@ -200,6 +200,7 @@ public class WiFiManagerPlugin extends CordovaPlugin {
     @TargetApi(Build.VERSION_CODES.Q)
     private void disconnectAndroidQ(CallbackContext callbackContext) {
         if (networkCallback != null) {
+            connectivityManager.bindProcessToNetwork(null);
             connectivityManager.unregisterNetworkCallback(networkCallback);
             networkCallback = null;
         }


### PR DESCRIPTION
When connecting to a network this plugin sets the new connection as default for the app process.
When the connection is dropped android tries to use that dropped connection that is not available anymore.
This PR unset the default connection so Android can use a new connection if available.